### PR TITLE
Windos Installer: Use the Registry to get the path to the installed node executable

### DIFF
--- a/build/windows/ioBroker.iss
+++ b/build/windows/ioBroker.iss
@@ -36,6 +36,7 @@ ArchitecturesInstallIn64BitMode=x64
 UninstallDisplayIcon={app}\{#MyAppIcon}
 CloseApplications=yes
 MissingRunOnceIdsWarning=no
+ChangesEnvironment=yes
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -151,7 +152,8 @@ end;
 
 function NodeJsPath(Param: String):String;
 begin
-  result := FileSearch('node.exe', GetEnv('PATH'));
+  result := '';
+  RegQueryStringValue(HKEY_LOCAL_MACHINE, 'SOFTWARE\Node.js', 'InstallPath', result);
   if (result <> '') then
   begin
     result := ExtractFilePath(result);
@@ -159,9 +161,10 @@ begin
   end
     else
   begin
-    Log( 'Node.js not found in path.');
+    Log( 'Node.js not found in registry.');
   end;
 end;
+
 function NodeJsNeedsInstall():boolean;
 var
   ResultCode: integer;
@@ -170,8 +173,8 @@ begin
   result := true;
   nodeExePath := NodeJsPath('');
   if (nodeExePath <> '') then
-  nodeExePath := nodeExePath + 'node.exe';
   begin
+    nodeExePath := nodeExePath + 'node.exe';
     result := not FileExists(nodeExePath);
     if not result then begin
       result := not CheckNodeJs(nodeExePath);

--- a/build/windows/ioBroker.iss
+++ b/build/windows/ioBroker.iss
@@ -149,52 +149,39 @@ begin
   end;
 end;
 
+function NodeJsPath(Param: String):String;
+begin
+  result := FileSearch('node.exe', GetEnv('PATH'));
+  if (result <> '') then
+  begin
+    result := ExtractFilePath(result);
+    Log(Format('Found Node.js path %s', [result]));
+  end
+    else
+  begin
+    Log( 'Node.js not found in path.');
+  end;
+end;
 function NodeJsNeedsInstall():boolean;
 var
   ResultCode: integer;
+  nodeExePath: string;
 begin
-
   result := true;
-  if IsWin64 then begin
-      result := not FileExists(ExpandConstant('{commonpf64}\nodejs\node.exe'));
-
-      if result then begin
-        result := not FileExists(ExpandConstant('{commonpf32}\nodejs\node.exe'));
-      end;
+  nodeExePath := NodeJsPath('');
+  if (nodeExePath <> '') then
+  nodeExePath := nodeExePath + 'node.exe';
+  begin
+    result := not FileExists(nodeExePath);
+    if not result then begin
+      result := not CheckNodeJs(nodeExePath);
+    end;
   end;
-
-  if result then begin
-    result := not FileExists(ExpandConstant('{commonpf}\nodejs\node.exe'));
-  end;
-
-  if not result then begin
-    result := not CheckNodeJs(ExpandConstant('{commonpf}\nodejs\node.exe'));
-  end;
-
   if not DirExists(ExpandConstant('{userappdata}\npm')) then begin
      Exec(ExpandConstant('mkdir'), ExpandConstant('{userappdata}\npm'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
   end;
   if not DirExists(ExpandConstant('{userappdata}\npm-cache')) then begin
      Exec(ExpandConstant('mkdir'), ExpandConstant('{userappdata}\npm-cache'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-  end;
-end;
-
-function NodeJsPath(Param: String):String;
-begin
-  result := '';
-
-  if DirExists(ExpandConstant('{commonpf}\nodejs')) then begin
-    result := ExpandConstant('{commonpf}\nodejs');
-  end;
-
-  if IsWin64 then begin
-      if DirExists(ExpandConstant('{commonpf32}\nodejs')) then begin
-        result := ExpandConstant('{commonpf32}\nodejs');
-      end;
-
-      if DirExists(ExpandConstant('{commonpf64}\nodejs')) then begin
-        result := ExpandConstant('{commonpf64}\nodejs');
-      end;
   end;
 end;
 


### PR DESCRIPTION
Use the path variable to get the used node executable. In the following installation steps node and npm are called without specific path, so the windows path variable is used. So the path should also be used to detect the version the used node.exe