### PR TITLE
Windows Installer: Corrected call of npx @iobroker/install

### DIFF
--- a/build/windows/ioBroker.iss
+++ b/build/windows/ioBroker.iss
@@ -220,7 +220,7 @@ Filename: "msiexec.exe"; Parameters: "/i ""{app}\node.msi"" /passive"; Check: No
 ;Filename: "{app}\serviceIoBroker.bat"; Parameters: "start"; WorkingDir: "{app}";
 ;
 ;Filename: "{code:NodeJsPath}\npx.cmd"; Parameters: "github:iobroker/iobroker#windows-installer"; WorkingDir: "{app}";
-Filename: "{code:NodeJsPath}\npx.cmd"; Parameters: "npx @iobroker/install"; WorkingDir: "{app}";
+Filename: "{code:NodeJsPath}\npx.cmd"; Parameters: "@iobroker/install"; WorkingDir: "{app}";
 ;
 ; Add Firewall Rules
 ; Filename: "{sys}\netsh.exe"; Parameters: "advfirewall firewall add rule name=""Node In"" program=""{code:NodeJsPath}\node.exe"" dir=in action=allow enable=yes"; Flags: runhidden;


### PR DESCRIPTION
Both, the Filename and the parameter contained "npx", which led at least on my system sometimes to strange results. Since I removed npx from the parameter, the installation runs fine on my test system.